### PR TITLE
Add proper support for touch events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2166,9 +2166,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.1.tgz",
-      "integrity": "sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.2.tgz",
+      "integrity": "sha512-ERxcZSoHx0EcN4HfshySEWmEf5Kkmgi+J7O79yCJ3xggzVlBJ2w/QjJUC+EBkJJ2OeSw48i3IoePN4w8JlVUIA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -2188,34 +2188,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "@jest/types": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
         },
         "ansi-styles": {
           "version": "4.2.1",
@@ -2257,18 +2229,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "pretty-format": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.3.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -2350,13 +2310,13 @@
       }
     },
     "@testing-library/react": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.0.2.tgz",
-      "integrity": "sha512-iOuNNHt4ZgMH5trSKC4kaWDcKzUOf7e7KQIcu7xvGCd68/w1EegbW89F9T5sZ4IjS0gAXdvOfZbG9ESZ7YjOug==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.0.4.tgz",
+      "integrity": "sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.11.2",
-        "@testing-library/dom": "^7.23.0"
+        "@testing-library/dom": "^7.24.2"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -10822,9 +10782,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
-      "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+      "version": "4.44.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
+      "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
@@ -11086,9 +11046,9 @@
       "dev": true
     },
     "yalc": {
-      "version": "1.0.0-pre.42",
-      "resolved": "https://registry.npmjs.org/yalc/-/yalc-1.0.0-pre.42.tgz",
-      "integrity": "sha512-iHelyFivjs0qgppWUVxb1wm1cN4gR9chPfFoBvwj1df3etS9MwQYGI6PqryYnr6vi/LUdTWGbAupf56i1mpfOA==",
+      "version": "1.0.0-pre.44",
+      "resolved": "https://registry.npmjs.org/yalc/-/yalc-1.0.0-pre.44.tgz",
+      "integrity": "sha512-qHcWyhAYSJ1KTYvlEZpC2w6LNd/xusQjcafZqdFiRJ6+WsaiRFnb9G5XFgU0G1TMG8Q7B4XrYg9Yp30HFzYmxQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "android-emulator-webrtc",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Android Emulator WebRTC module",
   "scripts": {
     "build": "webpack --mode production",
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.0.2",
+    "@testing-library/react": "^11.0.4",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.1.0",
@@ -46,9 +46,9 @@
     "react-docgen": "^5.3.0",
     "react-docgen-markdown-renderer": "^2.1.3",
     "react-dom": ">=16.8.0",
-    "webpack": "^4.44.1",
+    "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
-    "yalc": "^1.0.0-pre.42"
+    "yalc": "^1.0.0-pre.44"
   },
   "files": [
     "emulator/**"

--- a/src/components/emulator/views/event_handler.js
+++ b/src/components/emulator/views/event_handler.js
@@ -157,11 +157,15 @@ export default function withMouseKeyHandler(WrappedComponent) {
     };
 
     setTouchCoordinates = (type, touches) => {
+      // We need to calculate the offset of the touch events.
+      const rect = this.handler.current.getBoundingClientRect();
       const scaleCoordinates = this.scaleCoordinates;
       const touchesToSend = Object.keys(touches).map((index) => {
         const touch = touches[index];
         const { clientX, clientY, identifier, force, radiusX, radiusY } = touch;
-        const { x, y, scaleX, scaleY } = scaleCoordinates(clientX, clientY);
+        const offsetX = clientX - rect.left;
+        const offsetY = clientY - rect.top;
+        const { x, y, scaleX, scaleY } = scaleCoordinates(offsetX, offsetY);
         const scaledRadiusX = 2 * radiusX * scaleX;
         const scaledRadiusY = 2 * radiusY * scaleY;
 
@@ -170,8 +174,9 @@ export default function withMouseKeyHandler(WrappedComponent) {
         protoTouch.setY(y);
         protoTouch.setIdentifier(identifier);
         protoTouch.setPressure(force);
-        protoTouch.setTouchMajor(Math.max(scaledRadiusX, scaledRadiusY));
-        protoTouch.setTouchMinor(Math.min(scaledRadiusX, scaledRadiusY));
+        // These cause issues with touch events.
+        // protoTouch.setTouchMajor(Math.max(scaledRadiusX, scaledRadiusY));
+        // protoTouch.setTouchMinor(Math.min(scaledRadiusX, scaledRadiusY));
 
         return protoTouch;
       });
@@ -186,22 +191,30 @@ export default function withMouseKeyHandler(WrappedComponent) {
     handleTouchStart = (e) => {
       // Make sure they are not processed as mouse events later on.
       // See https://developer.mozilla.org/en-US/docs/Web/API/Touch_events
-      e.preventDefault();
-      this.setTouchCoordinates(e.nativeEvent.type, e.nativeEvent.touches);
+      if (e.cancelable) {
+        e.preventDefault();
+      }
+      this.setTouchCoordinates(e.nativeEvent.type, e.nativeEvent.changedTouches);
     };
 
     handleTouchMove = (e) => {
-      e.preventDefault();
-      this.setTouchCoordinates(e.nativeEvent.type, e.nativeEvent.touches);
+      if (e.cancelable) {
+        e.preventDefault();
+      }
+      this.setTouchCoordinates(e.nativeEvent.type, e.nativeEvent.changedTouches);
     };
 
     handleTouchEnd = (e) => {
-      e.preventDefault();
-      this.setTouchCoordinates(e.nativeEvent.type, e.nativeEvent.touches);
+      if (e.cancelable) {
+        e.preventDefault();
+      }
+      this.setTouchCoordinates(e.nativeEvent.type, e.nativeEvent.changedTouches);
     };
 
     preventDragHandler = (e) => {
-      e.preventDefault();
+      if (e.cancelable) {
+        e.preventDefault();
+      }
     };
 
     render() {


### PR DESCRIPTION
This fixes touch support for touch events.

- Use the proper event property
  See: https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/changedTouches
- Properly translate the touch event relative to the emulator view.
- Bumps the version to 1.0.3