### PR TITLE
Fix publishing bug in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
   - name: "gcr.io/cloud-builders/npm"
     args: ["install"]
   - name: "gcr.io/cloud-builders/npm"
-    args: ["build"]
+    args: ["run", "build"]
   - name: "gcr.io/cloud-builders/npm"
     args: ["test"]
   - name: "gcr.io/cloud-builders/npm"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "android-emulator-webrtc",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Android Emulator WebRTC module",
   "scripts": {
     "build": "babel src -d dist",


### PR DESCRIPTION
The master cloud script did not include the proper build tag, because of
this it did not publish the proper npm package.