### PR TITLE
Touch device trying to save png view as image

### DIFF
--- a/src/components/emulator/views/simple_png_view.js
+++ b/src/components/emulator/views/simple_png_view.js
@@ -124,7 +124,6 @@ export default class EmulatorPngView extends Component {
           height: "100%",
           objectFit: "contain",
           objectPosition: "center",
-
         }}
         onDragStart={this.preventDragHandler}
       >
@@ -136,7 +135,12 @@ export default class EmulatorPngView extends Component {
             );
           }}
         />
-        <img src={this.state.png} width="100%" draggable="false"/>
+        <img
+          src={this.state.png}
+          width="100%"
+          draggable="false"
+          style={{ pointerEvents: "none" }}
+        />
       </div>
     );
   }


### PR DESCRIPTION
When pressing the png view on slightly harder than normal without moving your finger on a touch device, you get asked if you want to save the view as an image to the device. This problem was resolved by disabling the pointer events for the internal <img> element