### PR TITLE
Fix missing remote candidates

### DIFF
--- a/src/components/emulator/net/jsep_protocol_driver.js
+++ b/src/components/emulator/net/jsep_protocol_driver.js
@@ -271,7 +271,7 @@ export default class JsepProtocol {
         this._handleSDP(this.old_emu_patch.sdp);
       }
 
-      if (this.haveOffer) {
+      if (this.old_emu_patch.haveOffer) {
         // We have a remote peer, add the candidates in.
         while (this.old_emu_patch.candidates.length > 0) {
           this._handleCandidate(this.old_emu_patch.candidates.shift());


### PR DESCRIPTION
I think this was just a typo. Once there's a peerConnection created, the code ignored all new remote candidates, breaking trickle ice.