### PR TITLE
Await on RTC peer connection promises

### DIFF
--- a/src/components/emulator/net/jsep_protocol_driver.js
+++ b/src/components/emulator/net/jsep_protocol_driver.js
@@ -232,14 +232,14 @@ export default class JsepProtocol {
   _handleSDP = async (signal) => {
     // We should not call this more than once..
     this.old_emu_patch.sdp = null;
-    this.peerConnection.setRemoteDescription(new RTCSessionDescription(signal));
+    await this.peerConnection.setRemoteDescription(new RTCSessionDescription(signal));
     const answer = await this.peerConnection.createAnswer();
     if (answer) {
       // Older emulators cannot handle multiple answers, so make sure we do not send one
       // again.
       if (!this.old_emu_patch.answer) {
         this.old_emu_patch.answer = true;
-        this.peerConnection.setLocalDescription(answer);
+        await this.peerConnection.setLocalDescription(answer);
         this._sendJsep({ sdp: answer });
       }
     } else {
@@ -247,8 +247,8 @@ export default class JsepProtocol {
     }
   };
 
-  _handleCandidate = (signal) => {
-    this.peerConnection.addIceCandidate(new RTCIceCandidate(signal));
+  _handleCandidate = async (signal) => {
+    await this.peerConnection.addIceCandidate(new RTCIceCandidate(signal));
   };
 
   _handleSignal = (signal) => {


### PR DESCRIPTION
RTCPeerConnection has many APIs that return a promise. This fixes the code to await on those promises.