### PR TITLE
cloudbuilders: update to include protoc-gen-js and handle aarch64

### DIFF
--- a/cloudbuilders/Dockerfile
+++ b/cloudbuilders/Dockerfile
@@ -3,18 +3,22 @@ FROM debian:buster-slim
 ARG VERS=23.1
 ARG ARCH=linux-x86_64
 ARG GRPC_WEB=1.4.2
+ARG JS=3.21.2
 
 RUN echo "Building protoc Cloud Builder ${VERS}-${ARCH}" && \
-    apt-get update -y && apt-get upgrade -y && \
-    apt-get install wget unzip -y && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    wget "https://github.com/protocolbuffers/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip" && \
-    unzip "protoc-${VERS}-${ARCH}.zip" -d protoc && \
-    wget "https://github.com/grpc/grpc-web/releases/download/${GRPC_WEB}/protoc-gen-grpc-web-${GRPC_WEB}-${ARCH}" -O /protoc/bin/protoc-gen-grpc-web && \
-    chmod a+x /protoc/bin/protoc-gen-grpc-web && \
-    rm "protoc-${VERS}-${ARCH}.zip"
+    apt-get update && \
+    apt-get install wget unzip make g++ -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-ENV PATH=$PATH:/protoc/bin/
+RUN wget "https://github.com/protocolbuffers/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip" && \
+    unzip "protoc-${VERS}-${ARCH}.zip" -d protoc && rm "protoc-${VERS}-${ARCH}.zip" && \
+    wget "https://github.com/grpc/grpc-web/releases/download/${GRPC_WEB}/protoc-gen-grpc-web-${GRPC_WEB}-$(printf $ARCH | sed s/aarch_64/aarch64/)" -O /protoc/bin/protoc-gen-grpc-web && \
+    chmod a+x /protoc/bin/protoc-gen-grpc-web && \
+    wget "https://github.com/protocolbuffers/protobuf-javascript/releases/download/v${JS}/protobuf-javascript-${JS}-${ARCH}.zip" && \
+    unzip "protobuf-javascript-${JS}-${ARCH}.zip" -d protoc-gen-js && rm "protobuf-javascript-${JS}-${ARCH}.zip"
+
+ENV PATH=$PATH:/protoc/bin/:/protoc-gen-js/bin/
+
 ENTRYPOINT ["protoc"]
 CMD ["--help"]


### PR DESCRIPTION
* `protoc-gen-js` is required but it's not included, hence the code-gen fails
* `linux-aarch_64` is needed for `protoc` and `protoc-gen-js` links but `protoc-gen-grpc-web` requires `linux-aarch64` so we do in place replacement with `sed`.